### PR TITLE
Fix spelling of 'unofficial'

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-Connectors, sockets and more (inofficial).
+Connectors, sockets and more (unofficial).
 
 ## License
 

--- a/library.lp
+++ b/library.lp
@@ -1,6 +1,6 @@
 (librepcb_library 58e570ce-a69e-466c-bbe0-65f716386e56
  (name "Phoenix")
- (description "Connectors, sockets and more (inofficial).")
+ (description "Connectors, sockets and more (unofficial).")
  (keywords "phoenix,contact,connectors")
  (author "LibrePCB")
  (version "0.1.1")


### PR DESCRIPTION
"Inofficial" should be spelled "unofficial"